### PR TITLE
Favour transmission network

### DIFF
--- a/src/jem/meta.py
+++ b/src/jem/meta.py
@@ -8,11 +8,11 @@
 metainfo = {
     "i_field": "from_id",
     "j_field": "to_id",
-    "cost_column": "length",
+    "cost_column": "length_over_voltage**2",
     "upper_bound": "max",
     "lower_bound": "min",
     "nodes_header": ["id", "asset_type", "subtype", "title", "capacity"],
-    "edges_header": ["id", "from_id", "to_id", "length", "min", "max"],
+    "edges_header": ["id", "from_id", "to_id", "length", "length_over_voltage**2", "min", "max"],
     "flow_header": [],
     "edge_index_variables": ["from_id", "to_id", "timestep"],
     "infrasim_cache": "../data/__infrasim__/",

--- a/src/jem/model.py
+++ b/src/jem/model.py
@@ -302,7 +302,6 @@ class jem:
             (
                 self.arcFlows[i, j, t]
                 <= upper_bound[i, j, t]
-                * 10**12  # TODO check if this is relaxing all upper bounds?
                 for i, j, t in self.arcFlows
             ),
             "upper_bound",

--- a/src/jem/utils.py
+++ b/src/jem/utils.py
@@ -251,7 +251,7 @@ def add_super_source(nodes, edges):
         {
             "from_id": "super_source",
             "to_id": nodes.id.unique(),
-            "length": constants["super_source_maximum"],
+            "length_over_voltage**2": constants["super_source_maximum"],
             "min": 0,
             "max": constants["super_source_maximum"],
         }
@@ -274,7 +274,7 @@ def add_super_sink(nodes, edges):
         {
             "from_id": nodes.id.unique(),
             "to_id": "super_sink",
-            "length": constants["super_source_maximum"],
+            "length_over_voltage**2": constants["super_source_maximum"],
             "min": 0,
             "max": constants["super_source_maximum"],
         }


### PR DESCRIPTION
Previously, we tried to allocate supply to demand, with an objective that minimised length of transmission line involved (while respecting conservation laws). This gave a bias towards using the distribution network for everything as the paths are often shorter than going via the transmission network and its infrequent substations.

How can we model losses?

Resistive losses are `P_loss = I^2 R` (1)
Power transmitted is`P=VIcos(theta)`, or `I = P/Vcos(theta)` (2)
So substituting (2) into (1): `P_loss=P^2 R / V^2 cos*2(theta)` (3)

Assume theta is constant. We have length and voltage information available. Resistance, `R` should be proportional to length, `L`. So, `L / V^2` can be used as a proxy to perform a more realistic allocation between different voltage classes. We are missing a `P^2` term compared to (3), which means allocation between lines within the same voltage class should favour lines with a lower loading, but will not.